### PR TITLE
Configurable options for RavenClient

### DIFF
--- a/aiomisc/service/raven.py
+++ b/aiomisc/service/raven.py
@@ -1,11 +1,13 @@
 import logging
+from typing import Mapping
 
 import yarl
-from aiomisc.service import Service
 from raven import Client
 from raven.handlers.logging import SentryHandler
 from raven.transport import Transport
 from raven_aiohttp import AioHttpTransport
+
+from aiomisc.service import Service
 
 
 log = logging.getLogger(__name__)
@@ -18,13 +20,16 @@ class DummyTransport(Transport):
 
 class RavenSender(Service):
     sentry_dsn = None               # type: yarl.URL
-    client = None                   # type: Client
+    client_options = None           # type: Mapping
     min_level = logging.WARNING     # type: int
+
+    client = None                   # type: Client
 
     async def start(self):
         self.client = Client(
             str(self.sentry_dsn),
-            transport=AioHttpTransport
+            transport=AioHttpTransport,
+            **(self.client_options or {})
         )
 
         self.sentry_dsn = yarl.URL(
@@ -37,7 +42,6 @@ class RavenSender(Service):
             client=self.client,
             level=self.min_level
         )
-        handler.setLevel(self.min_level)
 
         logging.getLogger().handlers.append(
             handler

--- a/aiomisc/service/raven.py
+++ b/aiomisc/service/raven.py
@@ -1,4 +1,5 @@
 import logging
+from types import MappingProxyType
 from typing import Mapping  # NOQA
 
 import yarl
@@ -19,17 +20,17 @@ class DummyTransport(Transport):
 
 
 class RavenSender(Service):
-    sentry_dsn = None               # type: yarl.URL
-    client_options = None           # type: Mapping
-    min_level = logging.WARNING     # type: int
+    sentry_dsn = None  # type: yarl.URL
+    min_level = logging.WARNING  # type: int
+    client_options = MappingProxyType({})  # type: Mapping
 
-    client = None                   # type: Client
+    client = None  # type: Client
 
     async def start(self):
         self.client = Client(
             str(self.sentry_dsn),
             transport=AioHttpTransport,
-            **(self.client_options or {})
+            **self.client_options
         )
 
         self.sentry_dsn = yarl.URL(

--- a/aiomisc/service/raven.py
+++ b/aiomisc/service/raven.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Mapping
+from typing import Mapping  # NOQA
 
 import yarl
 from raven import Client


### PR DESCRIPTION
RavenSender constructor can optionally receive `client_options` argument to specify custom options for the Raven client, such as `release`, `tags` and others.