### PR TITLE
Add `run_in_executor` function to aiomisc/thread_pool.py

### DIFF
--- a/aiomisc/thread_pool.py
+++ b/aiomisc/thread_pool.py
@@ -82,6 +82,14 @@ class ThreadPoolExecutor(Executor):
         self.shutdown()
 
 
+async def run_in_executor(func, *args, **kwargs):
+    loop = asyncio.get_event_loop()
+
+    return await loop.run_in_executor(
+        None, partial(func, *args, **kwargs)
+    )
+
+
 def threaded(func):
     @wraps(func)
     async def wrap(*args, **kwargs):

--- a/tests/test_thread_pool.py
+++ b/tests/test_thread_pool.py
@@ -1,10 +1,11 @@
 import asyncio
 from contextlib import suppress
+from functools import partial
 
 import pytest
 import time
 
-from aiomisc.thread_pool import ThreadPoolExecutor, threaded
+from aiomisc.thread_pool import ThreadPoolExecutor, run_in_executor, threaded
 
 
 @pytest.fixture
@@ -25,6 +26,22 @@ async def test_threaded(executor: ThreadPoolExecutor, timer):
     assert executor
 
     sleep = threaded(time.sleep)
+
+    with timer(1):
+        await asyncio.gather(
+            sleep(1),
+            sleep(1),
+            sleep(1),
+            sleep(1),
+            sleep(1),
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_in_executor(executor: ThreadPoolExecutor, timer):
+    assert executor
+
+    sleep = partial(run_in_executor, time.sleep)
 
     with timer(1):
         await asyncio.gather(


### PR DESCRIPTION
Simple utility function to avoid
```python
loop = asyncio.get_event_loop()
return await loop.run_in_executor(
    None, func, 123, test=2
)
```
boilerplate code.
Use it as simple as:
```python
from aiomisc.thread_pool import run_in_executor
...
run_in_executor(func, 123, test=2)
```