### PR TITLE
Support for None in `waterline` and/or `deadline` arguments

### DIFF
--- a/aiomisc/backoff.py
+++ b/aiomisc/backoff.py
@@ -1,7 +1,8 @@
 import asyncio
 from functools import wraps
 from time import monotonic
-from typing import Union, TypeVar, Type
+from typing import Optional, Type, TypeVar, Union
+
 from .timeout import timeout
 
 
@@ -12,17 +13,18 @@ T = TypeVar('T')
 class asyncbackoff:
     __slots__ = ('countdown', 'exceptions', 'pause', 'waterline')
 
-    def __init__(self, waterline: Number, deadline: Number,
+    def __init__(self, waterline: Optional[Number],
+                 deadline: Optional[Number],
                  pause: Number = 0, *exceptions: Type[Exception]):
 
         if pause < 0:
             raise ValueError("'pause' must be positive")
 
-        if waterline < 0:
-            raise ValueError("'waterline' must be positive")
+        if waterline is not None and waterline < 0:
+            raise ValueError("'waterline' must be positive or None")
 
-        if deadline < 0:
-            raise ValueError("'deadline' must be positive")
+        if deadline is not None and deadline < 0:
+            raise ValueError("'deadline' must be positive or None")
 
         self.exceptions = tuple(exceptions) or (Exception,)
         self.exceptions += asyncio.TimeoutError,
@@ -31,22 +33,25 @@ class asyncbackoff:
         self.countdown = deadline
 
     def __call__(self, func: T) -> T:
-        func = timeout(self.waterline)(func)
+        if self.waterline is not None:
+            func = timeout(self.waterline)(func)
 
         @wraps(func)
         async def wrap(*args, **kwargs):
-            while self.countdown > 0:
+            while self.countdown is None or self.countdown > 0:
                 started_at = monotonic()
 
                 try:
                     # noinspection PyCallingNonCallable
                     return await func(*args, **kwargs)
-                except self.exceptions:
-                    self.countdown -= monotonic() - started_at + self.pause
+                except self.exceptions as e:
+                    if self.countdown is not None:
+                        self.countdown -= monotonic() - started_at + self.pause
 
-                    if self.countdown <= 0:
-                        raise
-                    elif self.pause > 0:
+                        if self.countdown <= 0:
+                            raise
+
+                    if self.pause > 0:
                         await asyncio.sleep(self.pause)
 
                     continue

--- a/aiomisc/backoff.py
+++ b/aiomisc/backoff.py
@@ -44,7 +44,7 @@ class asyncbackoff:
                 try:
                     # noinspection PyCallingNonCallable
                     return await func(*args, **kwargs)
-                except self.exceptions as e:
+                except self.exceptions:
                     if self.countdown is not None:
                         self.countdown -= monotonic() - started_at + self.pause
 

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -24,7 +24,7 @@ async def test_already_done(event_loop):
 
 
 @pytest.mark.asyncio
-async def test_already_done(event_loop):
+async def test_already_done_2(event_loop):
     @timeout(0.5)
     async def test(sec):
         await asyncio.sleep(sec)


### PR DESCRIPTION
In `aiomisc.backoff`:`backoff` decorator.