### PR TITLE
Add pre-event-loo

### DIFF
--- a/aiomisc_pytest/pytest_plugin.py
+++ b/aiomisc_pytest/pytest_plugin.py
@@ -13,7 +13,6 @@ from socket import socket
 
 import pytest
 
-
 try:
     from inspect import isasyncgenfunction
 except ImportError:
@@ -163,23 +162,28 @@ def entrypoint_kwargs() -> dict:
     return {}
 
 
+@pytest.fixture
+def pre_event_loop() -> asyncio.AbstractEventLoop:
+    return asyncio.new_event_loop()
+
+
 @pytest.fixture(autouse=loop_autouse)
 def loop(services, loop_debug, default_context, entrypoint_kwargs,
-         thread_pool_size, thread_pool_executor, event_loop_policy):
+         thread_pool_size, thread_pool_executor, event_loop_policy,
+         pre_event_loop):
     from aiomisc.context import get_context
     from aiomisc.entrypoint import entrypoint
 
     asyncio.set_event_loop_policy(event_loop_policy)
 
-    event_loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(event_loop)
+    asyncio.set_event_loop(pre_event_loop)
 
     pool = thread_pool_executor(thread_pool_size)
-    event_loop.set_default_executor(pool)
+    pre_event_loop.set_default_executor(pool)
 
     try:
         with entrypoint(*services, pool_size=thread_pool_size,
-                        debug=loop_debug, loop=event_loop,
+                        debug=loop_debug, loop=pre_event_loop,
                         **entrypoint_kwargs) as event_loop:
 
             ctx = get_context(event_loop)


### PR DESCRIPTION
It's necessary when you need create object with with loop before creating of `loop` fixture