### PR TITLE
Allow `loop` fixture to be used in the aiomisc configuration fixtures

### DIFF
--- a/aiomisc_pytest/pytest_plugin.py
+++ b/aiomisc_pytest/pytest_plugin.py
@@ -151,7 +151,7 @@ def thread_pool_executor():
     return ThreadPoolExecutor
 
 
-@pytest.fixture
+@pytest.fixture(autouse=loop_autouse)
 def event_loop_policy():
     if uvloop:
         return uvloop.EventLoopPolicy()
@@ -163,7 +163,7 @@ def entrypoint_kwargs() -> dict:
     return {}
 
 
-@pytest.fixture(name='loop')
+@pytest.fixture(name='loop', autouse=loop_autouse)
 def _loop(event_loop_policy):
     asyncio.set_event_loop_policy(event_loop_policy)
     try:

--- a/tests/pytest_plugin/test_loop_fixture.py
+++ b/tests/pytest_plugin/test_loop_fixture.py
@@ -1,0 +1,27 @@
+import asyncio
+
+import pytest
+
+from aiomisc import Service
+
+
+class _TestService(Service):
+    loop_on_init = None  # type: asyncio.AbstractEventLoop
+
+    async def start(self):
+        assert self.loop is asyncio.get_event_loop()
+
+
+@pytest.fixture()
+def service(loop: asyncio.AbstractEventLoop):
+    return _TestService(loop_on_init=loop)
+
+
+@pytest.fixture()
+def services(service: _TestService):
+    return [service]
+
+
+async def test_loop_fixture(service: _TestService,
+                            loop: asyncio.AbstractEventLoop):
+    assert service.loop is service.loop_on_init is loop


### PR DESCRIPTION
Such as `services`, `default_context`, `entrypoint_kwargs` and others.
This change also improves the friendship with `pytest-aiohttp` library.